### PR TITLE
use named var for module loop to prevent CPAN::Distribution from overwriting it

### DIFF
--- a/lib/Test/DependentModules.pm
+++ b/lib/Test/DependentModules.pm
@@ -111,7 +111,9 @@ sub test_modules {
     }
     else {
         local $Test::Builder::Level = $Test::Builder::Level + 1;
-        test_module($_) for @_;
+        for my $module (@_) {
+            test_module($module);
+        }
     }
 }
 


### PR DESCRIPTION
Since test_modules uses @_ without copying it, the loop can end up with aliases to read-only values.  Several levels deeper, CPAN::Distribution will try to overwrite it, causing an error.

This changes a loop to use a named var instead of $_.
