### PR TITLE
don't fail on MB dists with no tests

### DIFF
--- a/lib/Test/DependentModules.pm
+++ b/lib/Test/DependentModules.pm
@@ -478,7 +478,8 @@ sub _run_tests {
     try {
         run3( $cmd, undef, \$output, $stderr );
         if ($? == 0) {
-            $passed = $output =~ /Result: (?:PASS|NOTESTS)|No tests defined/;
+            $passed = $output eq ''
+                    || $output =~ /Result: (?:PASS|NOTESTS)|No tests defined/;
         }
     }
     catch {


### PR DESCRIPTION
Module::Build has no output when run with --quiet if there are no tests, so adjust the test to account for that.
