### PR TITLE
fix installing modules after their prereqs have been met

### DIFF
--- a/lib/Test/DependentModules.pm
+++ b/lib/Test/DependentModules.pm
@@ -364,17 +364,14 @@ sub _install_prereqs {
         _install_prereq( $prereq->[0], $for_dist );
     }
 
-    # XXX basically just making this up (because the CPAN.pm source is
-    # impossible to follow), but ->make doesn't actually do anything if these
-    # keys exist
-    delete $dist->{configure_requires_later};
-    delete $dist->{configure_requires_later_for};
+    $dist->undelay;
 
     $dist->make();
 
     for my $prereq ( $dist->unsat_prereq('later') ) {
         _install_prereq( $prereq->[0], $for_dist );
     }
+    $dist->undelay;
 }
 
 sub _install_prereq {


### PR DESCRIPTION
When there are multiple levels of prerequisites and some duplicate their prereqs, the previous code would continue assuming that installation was waiting until after they were met.  This properly resets CPAN to try make/install etc instead of just skipping them.
