### PR TITLE
Correcting MetaCPAN::Client usage:

### DIFF
--- a/lib/Test/DependentModules.pm
+++ b/lib/Test/DependentModules.pm
@@ -61,10 +61,12 @@ sub _get_deps {
 
     my @deps;
     while ( my $dep = $rev_deps->next ) {
-        next unless $allow->($dep);
-        next if $dep =~ /^(?:Task|Bundle)/;
+        my $dist = $dep->distribution;
 
-        push @deps => $dep;
+        next unless $allow->($dist);
+        next if $dist =~ /^(?:Task|Bundle)/;
+
+        push @deps => $dist;
     }
 
     return @deps;


### PR DESCRIPTION
MetaCPAN::Client's reverse dependencies returns release objects.
You then need to use the "distribution" attribute, which provides
the distribution name.
