### PR TITLE
Make it explicit that this module needs Test::More

### DIFF
--- a/lib/Test/DependentModules.pm
+++ b/lib/Test/DependentModules.pm
@@ -524,6 +524,7 @@ __END__
 =head1 SYNOPSIS
 
     use Test::DependentModules qw( test_all_dependents );
+    use Test::More;
 
     test_all_dependents('My::Module');
 


### PR DESCRIPTION
Without Test::More, you will get:

Undefined subroutine &Test::More::diag called at /Users/rich/perl5/perlbrew/perls/perl-5.22.0/lib/site_perl/5.22.0/Test/DependentModules.pm line 509.